### PR TITLE
feat: support plantUML classDiagram syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ const defaultOutput = appRelationsDiscovery.getRelations(...docs);
 ```javascript
 const mermaidFlowchart = appRelationsDiscovery.getRelations(...docs,{syntax:'mermaid'});
 ```
+
+- For plantUML classDiagram 
+```javascript
+const plantUMLClassDiagram = appRelationsDiscovery.getRelations(...docs,{syntax:'plantUML'});
+```

--- a/lib/appRelationsDiscovery.js
+++ b/lib/appRelationsDiscovery.js
@@ -1,7 +1,8 @@
 const getMermaidFlowchart = require('./getMermaidFlowchart');
+const getPlantUMLDiagram = require('./getPlantUMLDiagram');
 const {validate} = require('./utils');
 
-const supportedSyntax = ['default','mermaid'];
+const supportedSyntax = ['default','mermaid','plantUML'];
 
 const defaultOptions = {
   syntax: 'default',
@@ -78,6 +79,8 @@ async function getRelations(asyncApiDocs, { syntax } = defaultOptions) {
     return metrics;
   if (syntax === 'mermaid')
     return getMermaidFlowchart(metrics);
+  if (syntax === 'plantUML')
+    return getPlantUMLDiagram(metrics);
 };
 
 module.exports = {getRelations};

--- a/lib/appRelationsDiscovery.js
+++ b/lib/appRelationsDiscovery.js
@@ -76,14 +76,12 @@ async function getRelations(asyncApiDocs, { syntax } = defaultOptions) {
     }
   });
   switch (syntax) {
-  case 'default':
-    return metrics;
   case 'mermaid':
     return getMermaidFlowchart(metrics);
   case 'plantUML':
     return getPlantUMLDiagram(metrics);
   default: 
-    throw new Error('The given syntax is not supported');
+    return metrics;
   }
 };
 

--- a/lib/appRelationsDiscovery.js
+++ b/lib/appRelationsDiscovery.js
@@ -12,7 +12,7 @@ const defaultOptions = {
  * Validates and analyzes a list of AsyncAPI documents and get applications described by those files
  * 
  * @param {Array} asyncApiDocs An array of asyncApiDocuments
- * @param {Object} options for getting a relations
+ * @param {Object} options {syntax: 'syntaxName'} supportedSyntax => default, mermaid, plantUML
  * @returns {Promise<DiscoveredRelations>} Relations between documents
  */
 // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/lib/appRelationsDiscovery.js
+++ b/lib/appRelationsDiscovery.js
@@ -12,7 +12,8 @@ const defaultOptions = {
  * Validates and analyzes a list of AsyncAPI documents and get applications described by those files
  * 
  * @param {Array} asyncApiDocs An array of asyncApiDocuments
- * @param {Object} options {syntax: 'syntaxName'} supportedSyntax => default, mermaid, plantUML
+ * @param {Object} [options]
+ * @param {('default'|'mermaid'|'plantUML')} [options.syntax] syntax in which the relation will be generated.
  * @returns {Promise<DiscoveredRelations>} Relations between documents
  */
 // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/lib/appRelationsDiscovery.js
+++ b/lib/appRelationsDiscovery.js
@@ -75,12 +75,16 @@ async function getRelations(asyncApiDocs, { syntax } = defaultOptions) {
       };
     }
   });
-  if (syntax === 'default')
+  switch (syntax) {
+  case 'default':
     return metrics;
-  if (syntax === 'mermaid')
+  case 'mermaid':
     return getMermaidFlowchart(metrics);
-  if (syntax === 'plantUML')
+  case 'plantUML':
     return getPlantUMLDiagram(metrics);
+  default: 
+    throw new Error('The given syntax is not supported');
+  }
 };
 
 module.exports = {getRelations};

--- a/lib/getPlantUMLDiagram.js
+++ b/lib/getPlantUMLDiagram.js
@@ -1,0 +1,30 @@
+/**
+ * Generates plantUML class diagram from default output syntax
+ * 
+ * @param {Object} metrics Relations between AsyncAPI docs in default output syntax
+ * @returns {String} class diagram following plantUML syntax
+ */
+function getPlantUMLDiagram(metrics) {
+  let i=1;
+  let plantUMLSyntax = '';
+  metrics.forEach((relations,server) => {
+    const [url, protocol] = server.split(',');
+    plantUMLSyntax+= `\nclass server${i} { \n url: ${url} \n protocol: ${protocol}\n}`;
+    
+    relations.forEach((operations, channel) => {
+      operations.sub.forEach((metadata,subscriber) => {
+        const service = subscriber.replace(/\s/g,'');
+        plantUMLSyntax+=`\n${service} --|> server${i}:${channel}`;
+      });
+    
+      operations.pub.forEach((metadata,publisher) => {
+        const service = publisher.replace(/\s/g,'');
+        plantUMLSyntax+=`\nserver${i} --|> ${service}:${channel}`;
+      });
+    });
+    i++;
+  });
+  return `@startuml\ntitle Classes - Class Diagram\n${plantUMLSyntax}\n@enduml`;
+}
+    
+module.exports = getPlantUMLDiagram;


### PR DESCRIPTION
This PR implements function to generate relations in plantUML classDiagram syntax.

Have a look at the plantUML classDiagram for flightService example [here](https://www.planttext.com/api/plantuml/png/V91B3e8m48RtFKKlG0XnGxem91ftkk44fGmmIQ4mdRfHJ-R28ta54MI1CUvcCj__o3plZyop9Wwj5OniGUwizXwyZEP9xb7Nf5iXpBHwe3DG8YzIo41MoNPWLd5idT6sSPvLagQRyTYJOsVSXn0tSR1ODtnq7RAZVBH10pAAhjl5KrKJ4OU-r0nYIPgGMNnoZ1N2eluIp4mU2cy82_YRCGG8FoFM_TPu1btvVjGB003__mC0).